### PR TITLE
Fix issues with AsyncLocal activity scope stack implementation

### DIFF
--- a/CorrelatorSharp.Tests/ActivityTrackingSpecs.cs
+++ b/CorrelatorSharp.Tests/ActivityTrackingSpecs.cs
@@ -94,10 +94,10 @@ namespace CorrelatorSharp.Tests
         };
     }
 
-    public class When_running_multiple_async_tasks
+    public class When_running_multiple_tasks
     {
         Because of = () => {
-            using (var scope = new ActivityScope("Root task scope", "Bob")) {
+            using (var scope = new ActivityScope("Root task scope", "PARENT-GUID")) {
                 var barrier = new Barrier(2);
                 var t1 = Task.Run((Action) (() => ChildTaskA(barrier, scope.Id)));
                 var t2 = Task.Run((Action) (() => ChildTaskB(barrier, scope.Id)));
@@ -105,7 +105,7 @@ namespace CorrelatorSharp.Tests
             }
         };
 
-        It should_preserve_correct_parents = () => {
+        It should_preserve_correct_parent = () => {
             // Expectations in child tasks
         };
 
@@ -115,7 +115,7 @@ namespace CorrelatorSharp.Tests
 
         private static void ChildTaskA(Barrier barrier, string expectedParentId)
         {
-            using (var scopeA = new ActivityScope("Child task A", "Bob 1")) {
+            using (var scopeA = new ActivityScope("Child task A", "CHILD-A-GUID")) {
                 barrier.SignalAndWait();
                 scopeA.ParentId.ShouldEqual(expectedParentId);
             }
@@ -123,8 +123,7 @@ namespace CorrelatorSharp.Tests
 
         private static void ChildTaskB(Barrier barrier, string expectedParentId)
         {
-            using (var scopeB = new ActivityScope("Child task B", "Bob 2"))
-            {
+            using (var scopeB = new ActivityScope("Child task B", "CHILD-B-GUID")) {
                 barrier.SignalAndWait();
                 scopeB.ParentId.ShouldEqual(expectedParentId);
             }

--- a/CorrelatorSharp.Tests/AsyncActivityTrackingSpecs.cs
+++ b/CorrelatorSharp.Tests/AsyncActivityTrackingSpecs.cs
@@ -81,6 +81,4 @@ namespace CorrelatorSharp.Tests
             Scope.Dispose();
         };
     }
-
- 
 }

--- a/CorrelatorSharp.Tests/CorrelatorSharp.Tests.csproj
+++ b/CorrelatorSharp.Tests/CorrelatorSharp.Tests.csproj
@@ -44,6 +44,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.0.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/CorrelatorSharp.Tests/packages.config
+++ b/CorrelatorSharp.Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Machine.Specifications" version="0.9.3" targetFramework="net46" />
   <package id="Machine.Specifications.Should" version="0.8.0" targetFramework="net46" />
+  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net46" />
 </packages>

--- a/CorrelatorSharp/CorrelatorSharp.csproj
+++ b/CorrelatorSharp/CorrelatorSharp.csproj
@@ -49,6 +49,9 @@
     <None Include="CorrelatorSharp.nuspec">
       <SubType>Designer</SubType>
     </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CorrelatorSharp/CorrelatorSharp.csproj
+++ b/CorrelatorSharp/CorrelatorSharp.csproj
@@ -46,8 +46,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="CorrelatorSharp.nuspec" />
-    <None Include="packages.config" />
+    <None Include="CorrelatorSharp.nuspec">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CorrelatorSharp/CorrelatorSharp.csproj
+++ b/CorrelatorSharp/CorrelatorSharp.csproj
@@ -32,6 +32,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.0.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
@@ -43,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="CorrelatorSharp.nuspec" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CorrelatorSharp/CorrelatorSharp.nuspec
+++ b/CorrelatorSharp/CorrelatorSharp.nuspec
@@ -8,6 +8,7 @@
     <projectUrl>https://github.com/CorrelatorSharp</projectUrl>
     <description>CorrelatorSharp</description>
     <dependencies>
+      <dependency id="Microsoft.Bcl.Immutable" version="[1.0,2.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/CorrelatorSharp/Properties/AssemblyInfo.cs
+++ b/CorrelatorSharp/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
-[assembly: AssemblyInformationalVersion("1.1.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyInformationalVersion("1.2.0")]

--- a/CorrelatorSharp/packages.config
+++ b/CorrelatorSharp/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net46" />
-</packages>

--- a/CorrelatorSharp/packages.config
+++ b/CorrelatorSharp/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net46" />
+</packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   release_version: '1.2.0'
-  release_assembly_version: '1.2.0.0'
+  release_assembly_version: '1.1.0.0'
   
 version: '$(release_version)+{build}'
 os: Visual Studio 2015

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
-  release_version: '1.1.0'
-  release_assembly_version: '1.1.0.0'
+  release_version: '1.2.0'
+  release_assembly_version: '1.2.0.0'
   
 version: '$(release_version)+{build}'
 os: Visual Studio 2015


### PR DESCRIPTION
Using ```AsyncLocal<Stack<ActivityScope>>```  creates race conditions and allows unexpected changes to occur to the activity scope stack when there are multiple async children running.  Implementing ```AsyncLocal<ImmutableStack<ActivityScope>>``` enforces copying and prevents these issues.

One particular issue it addresses is an exception we had been seeing of the form:
```
Stack empty. System.InvalidOperationException: Stack empty.\r\n   at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)\r\n   at System.Collections.Generic.Stack`1.Pop()\r\n   at CorrelatorSharp.ActivityTracker.End(ActivityScope scope)\r\n   at CorrelatorSharp.ActivityScope.Dispose()\r\n
```

It also addresses the issue where if you spawn two portions of async work, the second portion of async work would be inherit the first async as it's parent even if actually independent.

Added relevant test for this.