### PR TITLE
Replaced unlisted Microsoft.Bcl.Immutable with System.Collections.Immutable

### DIFF
--- a/CorrelatorSharp.Tests/CorrelatorSharp.Tests.csproj
+++ b/CorrelatorSharp.Tests/CorrelatorSharp.Tests.csproj
@@ -44,8 +44,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.0.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />

--- a/CorrelatorSharp.Tests/packages.config
+++ b/CorrelatorSharp.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Machine.Specifications" version="0.9.3" targetFramework="net46" />
   <package id="Machine.Specifications.Should" version="0.8.0" targetFramework="net46" />
-  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
 </packages>

--- a/CorrelatorSharp/CorrelatorSharp.csproj
+++ b/CorrelatorSharp/CorrelatorSharp.csproj
@@ -32,8 +32,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.0.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
@@ -49,9 +49,7 @@
     <None Include="CorrelatorSharp.nuspec">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CorrelatorSharp/CorrelatorSharp.nuspec
+++ b/CorrelatorSharp/CorrelatorSharp.nuspec
@@ -8,7 +8,7 @@
     <projectUrl>https://github.com/CorrelatorSharp</projectUrl>
     <description>CorrelatorSharp</description>
     <dependencies>
-      <dependency id="Microsoft.Bcl.Immutable" version="[1.0,2.0)" />
+      <dependency id="System.Collecctions.Immutable" version="[1.0,2.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/CorrelatorSharp/packages.config
+++ b/CorrelatorSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
[Microsoft.Bcl.Immutable](https://www.nuget.org/packages/Microsoft.Bcl.Immutable/) nuget has been unlisted and renamed to [System.Collections.Immutable](https://www.nuget.org/packages/System.Collections.Immutable/).

Modified the projects in the solution and the nuspec to have a dependency on the new renamed nuget instead of the old one.