### PR TITLE
Activity scope helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ thumbs.db
 .vs/
 .vscode/
 *.nupkg
+
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
+

--- a/CorrelatorSharp.Tests/ActivityScopeHelpers.cs
+++ b/CorrelatorSharp.Tests/ActivityScopeHelpers.cs
@@ -1,0 +1,120 @@
+﻿using Machine.Specifications;
+
+namespace CorrelatorSharp.Tests
+{
+    public class When_static_new_activity_scope_is_opened
+    {
+        static ActivityScope Scope;
+
+        Because of = () => {
+            Scope = ActivityScope.New("test");
+        };
+
+        It test_should_be_the_active_scope = () => {
+            ActivityScope.Current.ShouldNotBeNull();
+            ActivityScope.Current.Id.ShouldEqual(Scope.Id);
+        };
+
+        Cleanup cleanup = () => {
+            Scope.Dispose();
+        };
+    }
+
+    public class When_static_new_overwrites_existing
+    {
+        static ActivityScope ExistingScope1;
+        static ActivityScope ExistingScope2;
+        static ActivityScope NewScope;
+
+        Establish context = () => {
+            ExistingScope1 = new ActivityScope("test_1");
+            ExistingScope2 = new ActivityScope("test_2");
+        };
+
+        Because of = () => {
+            NewScope = ActivityScope.New("test_3");
+        };
+
+        It third_should_be_the_active_scope = () => {
+            ActivityScope.Current.ShouldNotBeNull();
+            ActivityScope.Current.Id.ShouldEqual(NewScope.Id);
+        };
+
+        It should_not_contain_second_scope = () => {
+            ActivityTracker.Find(ExistingScope2.Id).ShouldBeNull();
+        };
+
+        It should_contain_first_scope = () => {
+            ActivityTracker.Find(ExistingScope1.Id).ShouldNotBeNull();
+        };
+
+        Cleanup cleanup = () => {
+            ExistingScope1.Dispose();
+            ExistingScope2.Dispose();
+            NewScope.Dispose();
+        };
+    }
+
+    public class When_static_child_create_new
+    {
+        static ActivityScope ExistingScope;
+        static ActivityScope NewScope;
+
+        Establish context = () => {
+            ExistingScope = new ActivityScope("test_1");
+        };
+
+        Because of = () => {
+            NewScope = ActivityScope.Child("test_2");
+        };
+
+        It second_should_be_the_active_scope = () => {
+            ActivityScope.Current.ShouldNotBeNull();
+            ActivityScope.Current.Id.ShouldEqual(NewScope.Id);
+        };
+
+        It should_contain_existing_scope = () => {
+            ActivityTracker.Find(ExistingScope.Id).ShouldNotBeNull();
+        };
+
+        Cleanup cleanup = () => {
+            ExistingScope.Dispose();
+            NewScope.Dispose();
+        };
+    }
+
+    public class When_static_create_overwrites_all_existing
+    {
+        static ActivityScope ExistingScope1;
+        static ActivityScope ExistingScope2;
+        static ActivityScope NewScope;
+
+        Establish context = () => {
+            ExistingScope1 = new ActivityScope("test_1");
+            ExistingScope2 = new ActivityScope("test_2");
+        };
+
+        Because of = () => {
+            NewScope = ActivityScope.Create("test_3");
+        };
+
+        It third_should_be_the_active_scope = () => {
+            ActivityScope.Current.ShouldNotBeNull();
+            ActivityScope.Current.Id.ShouldEqual(NewScope.Id);
+        };
+
+        It should_not_contain_second_scope = () => {
+            ActivityTracker.Find(ExistingScope2.Id).ShouldBeNull();
+        };
+
+        It should_contain_first_scope = () => {
+            ActivityTracker.Find(ExistingScope1.Id).ShouldBeNull();
+        };
+
+        Cleanup cleanup = () => {
+            ExistingScope1.Dispose();
+            ExistingScope2.Dispose();
+            NewScope.Dispose();
+        };
+    }
+}

--- a/CorrelatorSharp.sln
+++ b/CorrelatorSharp.sln
@@ -1,55 +1,36 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FD05F83D-102E-432C-A9CA-03593C9731F6}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
 	EndProjectSection
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CorrelatorSharp.Tests", "CorrelatorSharp.Tests\CorrelatorSharp.Tests.csproj", "{8632001D-061F-46DF-A3BD-3403BABC088F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CorrelatorSharp.Tests", "CorrelatorSharp.Tests\CorrelatorSharp.Tests.csproj", "{4FDE2A3B-966E-4E67-BA1E-35D755E55A67}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CorrelatorSharp", "CorrelatorSharp\CorrelatorSharp.csproj", "{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CorrelatorSharp", "CorrelatorSharp\CorrelatorSharp.csproj", "{44A73131-27AF-4608-9F9A-A8AD9AA7D171}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Debug|x64.Build.0 = Debug|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Debug|x86.Build.0 = Debug|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Release|x64.ActiveCfg = Release|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Release|x64.Build.0 = Release|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Release|x86.ActiveCfg = Release|Any CPU
-		{8632001D-061F-46DF-A3BD-3403BABC088F}.Release|x86.Build.0 = Release|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Debug|x64.Build.0 = Debug|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Debug|x86.Build.0 = Debug|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Release|x64.ActiveCfg = Release|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Release|x64.Build.0 = Release|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Release|x86.ActiveCfg = Release|Any CPU
-		{EEB54A06-6EB0-498C-9DF8-2A6BD1F618CB}.Release|x86.Build.0 = Release|Any CPU
+		{4FDE2A3B-966E-4E67-BA1E-35D755E55A67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FDE2A3B-966E-4E67-BA1E-35D755E55A67}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FDE2A3B-966E-4E67-BA1E-35D755E55A67}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FDE2A3B-966E-4E67-BA1E-35D755E55A67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44A73131-27AF-4608-9F9A-A8AD9AA7D171}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44A73131-27AF-4608-9F9A-A8AD9AA7D171}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44A73131-27AF-4608-9F9A-A8AD9AA7D171}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44A73131-27AF-4608-9F9A-A8AD9AA7D171}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {C2FE012D-7786-4236-8D43-8A201394036F}
+		SolutionGuid = {250E251A-6753-437B-ACED-FFCA0528F059}
 	EndGlobalSection
 EndGlobal

--- a/CorrelatorSharp/ActivityScope.cs
+++ b/CorrelatorSharp/ActivityScope.cs
@@ -4,25 +4,46 @@ namespace CorrelatorSharp
 {
     public class ActivityScope : IDisposable
     {
-        public static ActivityScope Current {
-            get { return ActivityTracker.Current; }
-        }
+        /// <summary>
+        /// The current active <see cref="ActivityScope"/> for the current context.
+        /// </summary>
+        public static ActivityScope Current => ActivityTracker.Current;
 
+        /// <summary>
+        /// Creates new <see cref="ActivityScope"/> for given name with a <see cref="Guid"/>.<see cref="Guid.NewGuid"/> as ID.<para />
+        /// Sets this instance to the current active <see cref="ActivityScope"/> for context, see <see cref="Current"/>
+        /// </summary>
+        /// <param name="name">Human readable name for <see cref="ActivityScope"/></param>
         public ActivityScope(string name)
             : this(name, Guid.NewGuid().ToString())
         {
         }
 
+        /// <summary>
+        /// Creates new <see cref="ActivityScope"/> for given name, ID, and parent ID. Please ensure IDs are unique.<para />
+        /// Sets this instance to the current active <see cref="ActivityScope"/> for context, see <see cref="Current"/>
+        /// </summary>
+        /// <param name="name">Human readable name for <see cref="ActivityScope"/></param>
+        /// <param name="id">Please ensure IDs are unique.</param>
+        /// <param name="parentId">Please ensure IDs are unique.</param>
         public ActivityScope(string name, string id, string parentId)
             :this(name, id)
         {
             ParentId = parentId;
         }
 
+        /// <summary>
+        /// Creates new <see cref="ActivityScope"/> for given name and ID. Please ensure IDs are unique.<para />
+        /// Sets this instance to the current active <see cref="ActivityScope"/> for context, see <see cref="Current"/>
+        /// </summary>
+        /// <param name="name">Human readable name for <see cref="ActivityScope"/></param>
+        /// <param name="id">Please ensure IDs are unique.</param>
         public ActivityScope(string name, string id)
         {
             if (string.IsNullOrWhiteSpace(id))
+            {
                 throw new ArgumentException($"{nameof(id)} is null or empty.", nameof(id));
+            }
 
             Name = name;
             Id = id;
@@ -30,12 +51,66 @@ namespace CorrelatorSharp
             ActivityTracker.Start(this);
         }
 
-        public string Id { get; private set; }
+        /// <summary>
+        /// The given ID for the <see cref="ActivityScope"/>.
+        /// </summary>
+        public string Id { get; }
 
+        /// <summary>
+        /// The given Parent ID for the <see cref="ActivityScope"/>.
+        /// </summary>
         public string ParentId { get; internal set; }
 
+        /// <summary>
+        /// The given Name for the <see cref="ActivityScope"/>.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// Ends the <see cref="ActivityScope"/>.<see cref="Current"/> and 
+        /// creates new instance of <see cref="ActivityScope"/>.<see cref="Current"/> for given ID and name.<para />
+        /// <para />
+        /// Use only if you wish to clear <see cref="ActivityScope"/>.<see cref="Current"/>, you may be looking for <see cref="ActivityScope"/>.<see cref="Child"/>.
+        /// </summary>
+        /// <param name="name">Human readable name for <see cref="ActivityScope"/></param>
+        /// <param name="id">Optional, will default to <see cref="Guid"/>.<see cref="Guid.NewGuid"/>. Please ensure provided IDs are unique.</param>
+        /// <returns></returns>
+        public static ActivityScope New(string name, string id = null)
+        {
+            Current?.Dispose();
+            return new ActivityScope(name, id ?? Guid.NewGuid().ToString());
+        }
+
+        /// <summary>
+        /// Creates new instance of <see cref="ActivityScope"/>.<see cref="Current"/> for given ID and name,
+        /// with ParentID of previous <see cref="ActivityScope"/>.<see cref="Current"/>.<para />
+        /// </summary>
+        /// <param name="name">Human readable name for <see cref="ActivityScope"/></param>
+        /// <param name="id">Optional, will default to <see cref="Guid"/>.<see cref="Guid.NewGuid"/>. Please ensure provided IDs are unique.</param>
+        /// <returns></returns>
+        public static ActivityScope Child(string name, string id = null)
+        {
+            return new ActivityScope(name, id ?? Guid.NewGuid().ToString());
+        }
+
+        /// <summary>
+        /// Clears all parents for <see cref="ActivityScope"/>, and
+        /// creates new instance of <see cref="ActivityScope"/>.<see cref="Current"/> for given ID and name.<para />
+        /// <para />
+        /// Use only if you wish to clear all active <see cref="ActivityScope"/>, you may be looking for <see cref="ActivityScope"/>.<see cref="Child"/>.
+        /// </summary>
+        /// <param name="name">Human readable name for <see cref="ActivityScope"/></param>
+        /// <param name="id">Optional, will default to <see cref="Guid"/>.<see cref="Guid.NewGuid"/>. Please ensure provided IDs are unique.</param>
+        /// <returns></returns>
+        public static ActivityScope Create(string name, string id = null)
+        {
+            ActivityTracker.Clear();
+            return new ActivityScope(name, id ?? Guid.NewGuid().ToString());
+        }
+
+        /// <summary>
+        /// Disposes the instance and ends <see cref="ActivityScope"/>.<see cref="Current"/>.
+        /// </summary>
         public void Dispose()
         {
             ActivityTracker.End(this);

--- a/CorrelatorSharp/Headers.cs
+++ b/CorrelatorSharp/Headers.cs
@@ -3,5 +3,6 @@
     public static class Headers
     {
         public static readonly string CorrelationId = "X-Correlation-Id";
+        public static readonly string CorrelationName = "X-Correlation-Name";
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  package_version: '1.4.0-beta1'
+  package_version: '1.4.0'
   assembly_version: '1.1.0.0'
 
 version: '$(package_version)+{build}'


### PR DESCRIPTION
Add the methods from CorrelatorJS to activity scope:

`ActivityScope.New` - Creates a new sibling scope; useful if you want to spawn multiple children from same parent.

`ActivityScope.Child` - Create a new child scope; this is the same as `new ActivityScope` but looks cleaner and is more explicit than the 'new without assignment', or where the `using` pattern is not easy/possible or new block scope is not desired.

`ActivityScope.Create` - Creates a fresh scope with no parent; useful when in environments without obvious entry point or when you want to create a new scope in the current context.


Also added doc comments to `ActivityScope`, as that's basically the entire public API, and made bracketing style consistent.